### PR TITLE
Changed python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.7.3
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Changed Python version in Dockerfile for which certificates has no errors.
Our current certificate has 2048 bits length.
<img width="1405" alt="Screen Shot 2019-09-20 at 11 12 16 AM" src="https://user-images.githubusercontent.com/5380016/65328597-59013a80-dbbf-11e9-9e4a-ebf4abe39253.png">

We had similar issue in VGS Stripe Demo project.
Check PR below.
https://github.com/verygoodsecurity/vgs-stripe-demo/pull/10/files

Now it works with fixed Python version.
<img width="1439" alt="Screen Shot 2019-09-20 at 3 51 48 PM" src="https://user-images.githubusercontent.com/5380016/65331310-3e31c480-dbc5-11e9-8977-e0c1b426cad3.png">

